### PR TITLE
build(npm): update some libs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/preset-env": "^7.12.11",
         "@inquirer/prompts": "^4.1.0",
-        "@types/jest": "^29.5.3",
+        "@types/jest": "^29.5.12",
         "chalk": "^4.1.0",
         "commander": "^12.1.0",
         "inquirer": "^10.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@babel/preset-env": "^7.12.11",
+        "@babel/preset-env": "^7.25.3",
         "@inquirer/prompts": "^4.1.0",
         "@types/jest": "^29.5.12",
         "chalk": "^4.1.0",
@@ -17,9 +17,9 @@
         "inquirer": "^10.1.6",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
-        "log4js": "^6.4.0",
+        "log4js": "^6.9.1",
         "minimatch": "^9.0.3",
-        "moment": "^2.29.4",
+        "moment": "^2.30.1",
         "shelljs": "^0.8.5",
         "string-format": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@babel/preset-env": "^7.12.11",
     "@inquirer/prompts": "^4.1.0",
-    "@types/jest": "^29.5.3",
+    "@types/jest": "^29.5.12",
     "chalk": "^4.1.0",
     "commander": "^12.1.0",
     "inquirer": "^10.1.6",

--- a/package.json
+++ b/package.json
@@ -41,16 +41,16 @@
     "test": "npx jest --ci"
   },
   "dependencies": {
-    "@babel/preset-env": "^7.12.11",
+    "@babel/preset-env": "^7.25.3",
     "@inquirer/prompts": "^4.1.0",
     "@types/jest": "^29.5.12",
     "chalk": "^4.1.0",
     "commander": "^12.1.0",
     "inquirer": "^10.1.6",
     "lodash": "^4.17.21",
-    "log4js": "^6.4.0",
+    "log4js": "^6.9.1",
     "minimatch": "^9.0.3",
-    "moment": "^2.29.4",
+    "moment": "^2.30.1",
     "shelljs": "^0.8.5",
     "string-format": "^2.0.0",
     "js-yaml": "^4.1.0"


### PR DESCRIPTION
```
Patch   Backwards-compatible bug fixes
❯ ◉ @types/jest         ^29.5.3  →  ^29.5.12

Minor   Backwards-compatible features
  ◉ @babel/preset-env  ^7.12.11  →   ^7.25.3
  ◉ log4js               ^6.4.0  →    ^6.9.1
  ◉ moment              ^2.29.4  →   ^2.30.1
```