### PR TITLE
feat(config): add protection branch option and update related functionalities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths-ignore:
       - '**/README.md'
+      - '**/README**.md'
     branches:
       # - 'main'
       - 'release-*'

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $ git-tidier clear -l
 # delete all branches except the protection branch
 $ git-tidier clear -a
 
-# force delete
+# force delete. If there are unmerged commits in this branch, they will also be deleted successfully.
 $ git-tidier clear -f
 
 # Regular matching pattern support js regular expression custom search branch

--- a/README_zh.md
+++ b/README_zh.md
@@ -85,7 +85,7 @@ $ git-tidier clear -l
 # 删除, 除保护分支外的所有分支
 $ git-tidier clear -a
 
-# 强制删除
+# 强制删除。如果这个分支中有未合并的提交，它们也将被成功删除。
 $ git-tidier clear -f
 
 # 正则匹配模式 支持js正则表达式自定义检索分支

--- a/bin/git-tidier.js
+++ b/bin/git-tidier.js
@@ -19,7 +19,8 @@ if (!shell.which('git')) {
 
 program.version(app.version, '-v, --version');
 
-program.option('-f, --force', 'force to delete', false);
+program.option('-f, --force', 'force to delete, will not check branch has submitted but not merged', false);
+program.option('--protection <protection>', 'protection branch name', 'main');
 program.option('-r, --remote <remote>', 'the name of remote repo', 'origin');
 program.option(
   '-ig, --ignore <ignore...>',
@@ -40,7 +41,7 @@ program
   .description('clear git branch in current work directory')
   .option('-i, --interactive', 'clear git branch interactively', true)
   .option('-e, --execute', 'clear git branch by regexp')
-  .option('-a, --all', 'clear all git branch but master')
+  .option('-a, --all', 'clear all git branch but main')
   .option('-l, --local', 'just clear local branch', false)
   .option('-n, --number <number>', 'the number of safety branchs', 3)
   .option('-p, --pattern <pattern>', 'the pattern of match')

--- a/src/check.js
+++ b/src/check.js
@@ -3,8 +3,8 @@ const getGitBranchs = require('../src/utils/git/gitBranchTools').getGitBranchs;
 const pruneLocalRemote = require('../src/utils/git/gitBranchTools').pruneLocalRemote;
 
 module.exports = function (config = {}) {
-  const { number, ignore } = config;
-  const branchs = getGitBranchs(ignore || []);
+  const { number, ignore, protection } = config;
+  const branchs = getGitBranchs(protection, ignore || []);
   if (branchs.length <= Number(number)) {
     console.log(chalk.green('Ooo~ Your git is clean!'));
     pruneLocalRemote(config.remote);

--- a/src/interact.js
+++ b/src/interact.js
@@ -42,8 +42,8 @@ const getQuestions = (branchs, number) => {
 };
 
 const interactClear = (config = {}) => {
-  const { ignore, number, local, remote, force } = config;
-  const branchs = getGitBranchs(ignore || []);
+  const { ignore, number, local, remote, force, protection } = config;
+  const branchs = getGitBranchs(protection, ignore || []);
   const questions = getQuestions(branchs, number);
   pipe(branchs.map, questions, 0, deleteBranchItem, { local, remote, force });
 };

--- a/src/monster.js
+++ b/src/monster.js
@@ -43,9 +43,9 @@ const makeSure = () => {
 };
 
 const monsterClear = async (config = {}) => {
-  const { ignore, number, local, remote, force } = config;
+  const { ignore, number, local, remote, force, protection } = config;
 
-  const branchs = getGitBranchs(ignore || []);
+  const branchs = getGitBranchs(protection, ignore || []);
   const [removes, keeps] = filterBranchs(branchs, number);
 
   if (!removes.length) {

--- a/src/regexp.js
+++ b/src/regexp.js
@@ -44,9 +44,9 @@ const makeSure = () => {
 };
 
 const regexpClear = async (config = {}) => {
-  const { pattern, ignore, local, number, remote, force } = config;
+  const { pattern, ignore, local, number, remote, force, protection } = config;
   if (getRegExp(pattern)) {
-    const branchs = getGitBranchs(ignore || []);
+    const branchs = getGitBranchs(protection, ignore || []);
     const [removes, keeps] = filterBranchs(branchs, pattern, number);
 
     if (!removes.length) {

--- a/src/utils/git/gitBranchTools.js
+++ b/src/utils/git/gitBranchTools.js
@@ -10,12 +10,15 @@ const getGitBranchText = () => {
 
 // get current branchs
 // skip default is main
-exports.getGitBranchs = (ignores = []) => {
+exports.getGitBranchs = (protection = 'main', ignores = []) => {
   const text = getGitBranchText();
   const branchs = [];
   const map = {};
-  // skip master default
-  const skips = ['main'].concat(ignores);
+  if (protection === '') {
+    protection = 'main';
+  }
+  // skip main default
+  const skips = [protection].concat(ignores);
   text.split('\n').forEach((b, i) => {
     const sb = b.trim();
     // skip ignore branchs in config and current branch

--- a/tests/func.test.js
+++ b/tests/func.test.js
@@ -137,7 +137,7 @@ describe('test func getGitBranchs', () => {
 
   it('should return array without main and ignores', () => {
     shelljs.exec.mockReturnValueOnce({ stdout: branchs });
-    const values = getGitBranchs(['feat/202306-test1']);
+    const values = getGitBranchs('',['feat/202306-test1']);
     expect(values).toHaveLength(2);
     expect(values).toHaveProperty('map');
     // ignores and main


### PR DESCRIPTION
fix #139

- Add '--protection <protection>' option to specify the protection branch name
- Update 'getGitBranchs' function to use the specified protection branch
- Modify check, interact, monster, and regexp modules to use the new protection option
- Update tests to accommodate the new protection branch parameter
- fix desc of `--forece` of doc